### PR TITLE
Example for flexible domain support (optional)

### DIFF
--- a/js/sjsxc.config.sample.js
+++ b/js/sjsxc.config.sample.js
@@ -13,8 +13,17 @@ sjsxc.config = {
         /** domain part of your jid */
         domain: 'localhost',
 
-        /** which resource should be used? Blank, means random. */
-        resource: '',
+        /** optional function to fine-tune JID */
+        tuneJid: function(jid) {
+                // lastIndexOf(str, 0) is an efficient startsWith(str)
+                if (jid.lastIndexOf('user1@', 0) == 0) return 'user1@domain1.com/sogo';
+                if (jid.lastIndexOf('user2@', 0) == 0) return 'user2@domain2.com/sogo';
+                if (jid.lastIndexOf('user3@', 0) == 0) return 'user3@domain3.com/sogo';
+                return jid;
+        },
+
+        /** which resource should be used? Blank means random. */
+        resource: '/sogo',
 
         /** Allow user to overwrite xmpp settings? */
         overwrite: true,


### PR DESCRIPTION
A new optional function in the configuration settings will allow you to
support multiple domains or other dynamic translations between the
login name and the JID.
